### PR TITLE
Mappable CAOM2.4 Elements in casa_reader.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ For attempting upload, [Stephen's docker-compose setup](https://github.com/uksrc
 There is a simple test included in "test.py", the xml should be produced but the upload is expected to return a 403 permission denied with the current repository setup. 
 Change the input values within the file as necessary
 
+## Details of metadata collection from observatory measurement set
+
 emerlin2caom currently is comprised of a set of functions to interact with the measurement set data product via casatools, casa_reader.py.  This script still needs optimisation, to consolidate the number of opens to as few as possible.
 
-The main_app.py script contains an observation function which assigns metadata to caom elements for observations, planes and artifacts, and writes these to an xml file.  An argument could be made for abstracting this whole function out of main as this is effectively mapping out a 'blueprint'. The syntax needed for various elements by the caom2 code used to produce the XML for the database can be a bit diverse (documentation and data model and some blueprints say 'plane.energy.bandpassName', while what the code requires is actually 'plane.energy.bandpass_name', for example).  However, it may be helpful to see documentation on caom2tools/caom2/caom2 repository.  
+The main_app.py script contains an observation function which assigns metadata to caom elements for observations, planes and artifacts, and writes these to an xml file.  An argument could be made for abstracting this whole function out of main as this is effectively mapping out a 'blueprint'. The syntax needed for various elements by the caom2 code used to produce the XML for the database can be a bit diverse (documentation and data model and some blueprints say 'plane.energy.bandpassName', while what the code requires is actually 'plane.energy.bandpass_name', for example).  It may be helpful to see readme documentation on [caom2tools/caom2](https://github.com/opencadc/caom2tools/tree/main/caom2).  
 
 For collecting information on the actual data product artifact, the script to determine file type and discern measurement set status is called measurement_set_metadata.py.  This script needs renaming and reworking potentially to respond/interact with main_app.py with regard to determining other data product types such as 'image' or 'plot'.   

--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ For attempting upload, [Stephen's docker-compose setup](https://github.com/uksrc
 There is a simple test included in "test.py", the xml should be produced but the upload is expected to return a 403 permission denied with the current repository setup. 
 Change the input values within the file as necessary
 
+emerlin2caom currently is comprised of a set of functions to interact with the measurement set data product via casatools, casa_reader.py.  This script still needs optimisation, to consolidate the number of opens to as few as possible.
+
+The main_app.py script contains an observation function which assigns metadata to caom elements for observations, planes and artifacts, and writes these to an xml file.  An argument could be made for abstracting this whole function out of main as this is effectively mapping out a 'blueprint'. The syntax needed for various elements by the caom2 code used to produce the XML for the database can be a bit diverse (documentation and data model and some blueprints say 'plane.energy.bandpassName', while what the code requires is actually 'plane.energy.bandpass_name', for example).  However, it may be helpful to see documentation on caom2tools/caom2/caom2 repository.  
+
+For collecting information on the actual data product artifact, the script to determine file type and discern measurement set status is called measurement_set_metadata.py.  This script needs renaming and reworking potentially to respond/interact with main_app.py with regard to determining other data product types such as 'image' or 'plot'.   

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -4,6 +4,7 @@ import casatools
 
 msmd = casatools.msmetadata()
 ms = casatools.ms()
+tb = casatools.table()
 
 
 def find_mssources(ms_file):
@@ -14,13 +15,12 @@ def find_mssources(ms_file):
     """
     # Get list of sources from measurement set
     # To do: discern target and calibrators for CAOM Observation.targetName
+    # To do: Determine if each source a keyword or one keyword with list of sources.
     msmd.open(ms_file)
     # mssources = ','.join(numpy.sort(msmd.fieldnames()))
     mssources = msmd.fieldnames()
     msmd.done()
-    # logger.debug('Sources in MS {0}: {1}'.format(msfile, mssources))
     return mssources
-
 
 def get_obs_name(ms_file):
     """
@@ -52,12 +52,14 @@ def energy_bounds(ms_file):
     nspw = msmd.nspw()
     freq_ini = msmd.chanfreqs(0)[0]
     freq_end = msmd.chanfreqs(nspw-1)[-1]
+    msmd.close()
     wl_upper = freq2wl(freq_ini)
     wl_lower = freq2wl(freq_end)
     return wl_upper, wl_lower
 
 def get_bandpass(ms_file):
     # Returns eMERLIN name for bandpass CAOM energy.bandpass_name
+    # Also, could get from MS file name.
     # To do: Combine with get_obsfreq for one open on nspw?
     msmd.open(ms_file)
     freq = msmd.chanfreqs(0)[0]/1e9
@@ -74,7 +76,18 @@ def get_bandpass(ms_file):
         band = 'Null'
     return band
 
-
+def get_polar(ms_file):
+    """
+    Get polarisation state
+    :param ms_file: Name of measurement set
+    :returns: polarization type and number of dimensions.
+    """
+    tb.open(ms_file+'/FEED')
+    polarization = tb.getcol('POLARIZATION_TYPE')
+    pol_dim = tb.getcol('NUM_RECEPTORS')[0]
+    tb.close()
+    pol_type = list(polarization[:,0])    
+    return pol_type, pol_dim
 
 def get_scan_sum(ms_file):
     """

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -56,6 +56,26 @@ def energy_bounds(ms_file):
     wl_lower = freq2wl(freq_end)
     return wl_upper, wl_lower
 
+def get_bandpass(ms_file):
+    # Returns eMERLIN name for bandpass CAOM energy.bandpass_name
+    # To do: Combine with get_obsfreq for one open on nspw?
+    msmd.open(ms_file)
+    freq = msmd.chanfreqs(0)[0]/1e9
+    msmd.done()
+    band = ''
+    if (freq > 1.2) and (freq < 1.7):
+        band = 'L'
+    elif (freq > 4) and (freq < 8):
+        band = 'C'
+    elif (freq > 17) and (freq < 26):
+        band = 'K'
+    else:
+        print('Cannot determine band from frequency')
+        band = 'Null'
+    return band
+
+
+
 def get_scan_sum(ms_file):
     """
     Get summary for scan information

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -15,8 +15,8 @@ def find_mssources(ms_file):
     # Get list of sources from measurement set
     # To do: discern target and calibrators for CAOM Observation.targetName
     msmd.open(ms_file)
-    mssources = ','.join(numpy.sort(msmd.fieldnames()))
-    # mssources = msmd.fieldnames()
+    # mssources = ','.join(numpy.sort(msmd.fieldnames()))
+    mssources = msmd.fieldnames()
     msmd.done()
     # logger.debug('Sources in MS {0}: {1}'.format(msfile, mssources))
     return mssources
@@ -31,7 +31,7 @@ def get_obs_name(ms_file):
     msmd.open(ms_file)
     obs_name = msmd.observatorynames()
     msmd.done()
-    return obs_name[0]
+    return obs_name
 
 def get_antennas(ms_file):
     # Returns Antenna names list included in interferometer for this obs

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -33,6 +33,28 @@ def get_obs_name(ms_file):
     msmd.done()
     return obs_name[0]
 
+def get_antennas(ms_file):
+    # Returns Antenna names list included in interferometer for this obs
+    msmd.open(ms_file)
+    antennas = msmd.antennanames()
+    msmd.close()
+    return antennas
+
+def freq2wl(freq):
+    # Convert frequency (Hz) to wavelength (m)
+    sol = 299792458
+    wl = sol/freq
+    return wl
+
+def energy_bounds(ms_file):
+    # Return energy bounds in wavelength (m)
+    msmd.open(ms_file)
+    nspw = msmd.nspw()
+    freq_ini = msmd.chanfreqs(0)[0]
+    freq_end = msmd.chanfreqs(nspw-1)[-1]
+    wl_upper = freq2wl(freq_ini)
+    wl_lower = freq2wl(freq_end)
+    return wl_upper, wl_lower
 
 def get_scan_sum(ms_file):
     """

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -74,8 +74,8 @@ entry point that executes the workflow.
 import os
 import subprocess
 
-from caom2 import SimpleObservation, ObservationIntentType, Target, Telescope, TypedOrderedDict, Plane, Artifact, \
-    ReleaseType, ObservationWriter, ProductType, ChecksumURI
+from caom2 import SimpleObservation, ObservationIntentType, Target, Telescope, TypedOrderedDict, Plane, Artifact, Energy, \
+    EnergyBand, Interval, ReleaseType, ObservationWriter, ProductType, ChecksumURI
 
 import casa_reader as casa
 import measurement_set_metadata as msmd
@@ -120,9 +120,17 @@ def create_observation(storage_name, xml_out_dir):
     plane = Plane(obs_id)
     observation.planes[obs_id] = plane
 
-    #energy_bounds_u, energy_bounds_l = casa.energy_bounds(storage_name)
-    #plane.energy.bounds.lower = energy_bounds_l
-    #plane.energy.bounds.upper = energy_bounds_u    
+    # Make an Energy object for this Plane.
+    plane.energy = Energy()
+   
+    # Assign Energy object metadata, so far only bounds works.
+    energy_u, energy_l = casa.energy_bounds(storage_name)
+    plane.energy.bounds = Interval(energy_l, energy_u)
+
+    # These don't break anything but also aren't printed to xml...
+    plane.energy.bandpassName = 'TBD'
+    plane.energy.energyBands = "EnergyBand.RADIO"
+
 
     plane.artifacts = TypedOrderedDict(Artifact)
     artifact = Artifact('uri:foo/bar', ProductType.SCIENCE, ReleaseType.META)

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -111,18 +111,18 @@ def create_observation(storage_name, xml_out_dir):
     observation.intent = ObservationIntentType.SCIENCE
 
     observation.target = Target('TBD')
-    observation.target.keywords = Target(casa.find_mssources(storage_name))
+    observation.target.keywords = set(casa.find_mssources(storage_name))
     # observation.target.position = TargetPosition(str(find_mssources(ms_file)), 'J2000')
     observation.telescope = Telescope(casa.get_obs_name(storage_name)[0])
-    observation.telescope.keywords = Telescope(casa.get_antennas(storage_name))
+    observation.telescope.keywords = set(casa.get_antennas(storage_name))
 
     observation.planes = TypedOrderedDict(Plane)
     plane = Plane(obs_id)
     observation.planes[obs_id] = plane
 
-    energy_bounds_u, energy_bounds_l = casa.energy_bounds(storage_name)
-    plane.energy.bounds.lower = energy_bounds_l
-    plane.energy.bounds.upper = energy_bounds_u    
+    #energy_bounds_u, energy_bounds_l = casa.energy_bounds(storage_name)
+    #plane.energy.bounds.lower = energy_bounds_l
+    #plane.energy.bounds.upper = energy_bounds_u    
 
     plane.artifacts = TypedOrderedDict(Artifact)
     artifact = Artifact('uri:foo/bar', ProductType.SCIENCE, ReleaseType.META)
@@ -174,7 +174,7 @@ def emerlin_main_app(storage_name, rootca=None, xml_dir='.'):
     :param xml_dir: directory for storage of xml output
     """
     xml_output_file, obs_id = create_observation(storage_name, xml_dir)
-    upload_xml(xml_output_file, obs_id, rootca)
+    #upload_xml(xml_output_file, obs_id, rootca)
     # add something like this for logging later
     # try:
     #     result = to_caom2()

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -111,12 +111,18 @@ def create_observation(storage_name, xml_out_dir):
     observation.intent = ObservationIntentType.SCIENCE
 
     observation.target = Target('TBD')
+    observation.target.keywords = Target(casa.find_mssources(storage_name))
     # observation.target.position = TargetPosition(str(find_mssources(ms_file)), 'J2000')
     observation.telescope = Telescope(casa.get_obs_name(storage_name)[0])
+    observation.telescope.keywords = Telescope(casa.get_antennas(storage_name))
 
     observation.planes = TypedOrderedDict(Plane)
     plane = Plane(obs_id)
     observation.planes[obs_id] = plane
+
+    energy_bounds_u, energy_bounds_l = casa.energy_bounds(storage_name)
+    plane.energy.bounds.lower = energy_bounds_l
+    plane.energy.bounds.upper = energy_bounds_u    
 
     plane.artifacts = TypedOrderedDict(Artifact)
     artifact = Artifact('uri:foo/bar', ProductType.SCIENCE, ReleaseType.META)

--- a/emerlin2caom2/test.py
+++ b/emerlin2caom2/test.py
@@ -1,7 +1,7 @@
 import main_app
 
-rootca = '/home/h14471mj/e-merlin/em_github/caom_env/caomdev/ssl/rootCA.crt'
-storage_name = '/home/h14471mj/e-merlin/casa6_docker/prod/TS8004_C_001_20190801/TS8004_C_001_20190801_avg.ms'
-xmldir = './data/'
+rootca = '/Users/user/repos/emerlin2caom/scripts/rootCA.pem'
+storage_name = '/Users/user/dataReduction/TS8004_C_001_20190801/TS8004_C_001_20190801/TS8004_C_001_20190801_avg.ms'
+xmldir = '/Users/user/repos/emerlin2caom/output_xml/'
 
 main_app.emerlin_main_app(storage_name, rootca=rootca, xml_dir=xmldir)

--- a/emerlin2caom2/test.py
+++ b/emerlin2caom2/test.py
@@ -1,7 +1,7 @@
 import main_app
 
 rootca = '/Users/user/repos/emerlin2caom/scripts/rootCA.pem'
-storage_name = '/Users/user/dataReduction/TS8004_C_001_20190801/TS8004_C_001_20190801/TS8004_C_001_20190801_avg.ms'
+storage_name = '/Users/user/dataReduction/TS8004_C_001_20190801/TS8004_C_001_20190801_avg.ms'
 xmldir = '/Users/user/repos/emerlin2caom/output_xml/'
 
 main_app.emerlin_main_app(storage_name, rootca=rootca, xml_dir=xmldir)

--- a/output_xml/TS8004_C_001_20190801.xml
+++ b/output_xml/TS8004_C_001_20190801.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="dba8e6e0-5b19-449a-bc30-2d93a3b8ae39">
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="887adddc-4757-43bc-aaa7-1af6ab99d39e">
   <caom2:collection>collection</caom2:collection>
   <caom2:observationID>TS8004_C_001_20190801</caom2:observationID>
   <caom2:algorithm>
@@ -9,26 +9,26 @@
   <caom2:target>
     <caom2:name>TBD</caom2:name>
     <caom2:keywords>
-      <caom2:keyword>1252+5634</caom2:keyword>
       <caom2:keyword>1302+5748</caom2:keyword>
-      <caom2:keyword>0319+4130</caom2:keyword>
-      <caom2:keyword>1407+2827</caom2:keyword>
       <caom2:keyword>1331+3030</caom2:keyword>
+      <caom2:keyword>1407+2827</caom2:keyword>
+      <caom2:keyword>1252+5634</caom2:keyword>
+      <caom2:keyword>0319+4130</caom2:keyword>
     </caom2:keywords>
   </caom2:target>
   <caom2:telescope>
     <caom2:name>e-MERLIN</caom2:name>
     <caom2:keywords>
+      <caom2:keyword>Kn</caom2:keyword>
       <caom2:keyword>Mk2</caom2:keyword>
       <caom2:keyword>Pi</caom2:keyword>
-      <caom2:keyword>Kn</caom2:keyword>
       <caom2:keyword>Cm</caom2:keyword>
       <caom2:keyword>De</caom2:keyword>
       <caom2:keyword>Da</caom2:keyword>
     </caom2:keywords>
   </caom2:telescope>
   <caom2:planes>
-    <caom2:plane caom2:id="cafc12ae-a849-4696-ac62-6b98a8e2da74">
+    <caom2:plane caom2:id="9ee6947e-834b-4cf6-8d87-3b6f360ff551">
       <caom2:productID>TS8004_C_001_20190801</caom2:productID>
       <caom2:calibrationLevel>2</caom2:calibrationLevel>
       <caom2:energy>
@@ -42,7 +42,7 @@
         <caom2:dimension>2</caom2:dimension>
       </caom2:polarization>
       <caom2:artifacts>
-        <caom2:artifact caom2:id="cec64d52-5d85-4d71-9b71-eb3957a04f24">
+        <caom2:artifact caom2:id="d706b841-3d01-492d-ab81-39b8185b2882">
           <caom2:uri>uri:foo/bar</caom2:uri>
           <caom2:productType>science</caom2:productType>
           <caom2:releaseType>meta</caom2:releaseType>

--- a/output_xml/TS8004_C_001_20190801.xml
+++ b/output_xml/TS8004_C_001_20190801.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="3005fc02-74df-41b2-8d90-8f752372d76a">
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="dba8e6e0-5b19-449a-bc30-2d93a3b8ae39">
   <caom2:collection>collection</caom2:collection>
   <caom2:observationID>TS8004_C_001_20190801</caom2:observationID>
   <caom2:algorithm>
@@ -9,26 +9,26 @@
   <caom2:target>
     <caom2:name>TBD</caom2:name>
     <caom2:keywords>
+      <caom2:keyword>1252+5634</caom2:keyword>
+      <caom2:keyword>1302+5748</caom2:keyword>
+      <caom2:keyword>0319+4130</caom2:keyword>
       <caom2:keyword>1407+2827</caom2:keyword>
       <caom2:keyword>1331+3030</caom2:keyword>
-      <caom2:keyword>1302+5748</caom2:keyword>
-      <caom2:keyword>1252+5634</caom2:keyword>
-      <caom2:keyword>0319+4130</caom2:keyword>
     </caom2:keywords>
   </caom2:target>
   <caom2:telescope>
     <caom2:name>e-MERLIN</caom2:name>
     <caom2:keywords>
       <caom2:keyword>Mk2</caom2:keyword>
-      <caom2:keyword>Da</caom2:keyword>
-      <caom2:keyword>De</caom2:keyword>
       <caom2:keyword>Pi</caom2:keyword>
-      <caom2:keyword>Cm</caom2:keyword>
       <caom2:keyword>Kn</caom2:keyword>
+      <caom2:keyword>Cm</caom2:keyword>
+      <caom2:keyword>De</caom2:keyword>
+      <caom2:keyword>Da</caom2:keyword>
     </caom2:keywords>
   </caom2:telescope>
   <caom2:planes>
-    <caom2:plane caom2:id="76cb027b-3548-4835-92a4-420f613409b9">
+    <caom2:plane caom2:id="cafc12ae-a849-4696-ac62-6b98a8e2da74">
       <caom2:productID>TS8004_C_001_20190801</caom2:productID>
       <caom2:calibrationLevel>2</caom2:calibrationLevel>
       <caom2:energy>
@@ -38,8 +38,11 @@
         </caom2:bounds>
         <caom2:bandpassName>C</caom2:bandpassName>
       </caom2:energy>
+      <caom2:polarization>
+        <caom2:dimension>2</caom2:dimension>
+      </caom2:polarization>
       <caom2:artifacts>
-        <caom2:artifact caom2:id="ade59b3f-bf71-4925-8d95-e055698e1fb0">
+        <caom2:artifact caom2:id="cec64d52-5d85-4d71-9b71-eb3957a04f24">
           <caom2:uri>uri:foo/bar</caom2:uri>
           <caom2:productType>science</caom2:productType>
           <caom2:releaseType>meta</caom2:releaseType>

--- a/output_xml/TS8004_C_001_20190801.xml
+++ b/output_xml/TS8004_C_001_20190801.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="2f640f88-1973-433d-bb7c-06e2e7f53b23">
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="3005fc02-74df-41b2-8d90-8f752372d76a">
   <caom2:collection>collection</caom2:collection>
   <caom2:observationID>TS8004_C_001_20190801</caom2:observationID>
   <caom2:algorithm>
@@ -9,35 +9,37 @@
   <caom2:target>
     <caom2:name>TBD</caom2:name>
     <caom2:keywords>
-      <caom2:keyword>1331+3030</caom2:keyword>
       <caom2:keyword>1407+2827</caom2:keyword>
+      <caom2:keyword>1331+3030</caom2:keyword>
       <caom2:keyword>1302+5748</caom2:keyword>
-      <caom2:keyword>0319+4130</caom2:keyword>
       <caom2:keyword>1252+5634</caom2:keyword>
+      <caom2:keyword>0319+4130</caom2:keyword>
     </caom2:keywords>
   </caom2:target>
   <caom2:telescope>
     <caom2:name>e-MERLIN</caom2:name>
     <caom2:keywords>
-      <caom2:keyword>Kn</caom2:keyword>
+      <caom2:keyword>Mk2</caom2:keyword>
+      <caom2:keyword>Da</caom2:keyword>
+      <caom2:keyword>De</caom2:keyword>
       <caom2:keyword>Pi</caom2:keyword>
       <caom2:keyword>Cm</caom2:keyword>
-      <caom2:keyword>De</caom2:keyword>
-      <caom2:keyword>Da</caom2:keyword>
-      <caom2:keyword>Mk2</caom2:keyword>
+      <caom2:keyword>Kn</caom2:keyword>
     </caom2:keywords>
   </caom2:telescope>
   <caom2:planes>
-    <caom2:plane caom2:id="62e0e669-0e29-441c-9ad9-88f63db89024">
+    <caom2:plane caom2:id="76cb027b-3548-4835-92a4-420f613409b9">
       <caom2:productID>TS8004_C_001_20190801</caom2:productID>
+      <caom2:calibrationLevel>2</caom2:calibrationLevel>
       <caom2:energy>
         <caom2:bounds>
           <caom2:lower>0.056272634068512434</caom2:lower>
           <caom2:upper>0.06224280244991176</caom2:upper>
         </caom2:bounds>
+        <caom2:bandpassName>C</caom2:bandpassName>
       </caom2:energy>
       <caom2:artifacts>
-        <caom2:artifact caom2:id="9690c597-f534-4679-be41-003943157e38">
+        <caom2:artifact caom2:id="ade59b3f-bf71-4925-8d95-e055698e1fb0">
           <caom2:uri>uri:foo/bar</caom2:uri>
           <caom2:productType>science</caom2:productType>
           <caom2:releaseType>meta</caom2:releaseType>

--- a/output_xml/TS8004_C_001_20190801.xml
+++ b/output_xml/TS8004_C_001_20190801.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="94ed5d99-af06-4cfe-be9b-485a68d79d20">
+  <caom2:collection>collection</caom2:collection>
+  <caom2:observationID>TS8004_C_001_20190801</caom2:observationID>
+  <caom2:algorithm>
+    <caom2:name>exposure</caom2:name>
+  </caom2:algorithm>
+  <caom2:intent>science</caom2:intent>
+  <caom2:target>
+    <caom2:name>TBD</caom2:name>
+    <caom2:keywords>
+      <caom2:keyword>1252+5634</caom2:keyword>
+      <caom2:keyword>1302+5748</caom2:keyword>
+      <caom2:keyword>0319+4130</caom2:keyword>
+      <caom2:keyword>1331+3030</caom2:keyword>
+      <caom2:keyword>1407+2827</caom2:keyword>
+    </caom2:keywords>
+  </caom2:target>
+  <caom2:telescope>
+    <caom2:name>e-MERLIN</caom2:name>
+    <caom2:keywords>
+      <caom2:keyword>Mk2</caom2:keyword>
+      <caom2:keyword>De</caom2:keyword>
+      <caom2:keyword>Kn</caom2:keyword>
+      <caom2:keyword>Cm</caom2:keyword>
+      <caom2:keyword>Pi</caom2:keyword>
+      <caom2:keyword>Da</caom2:keyword>
+    </caom2:keywords>
+  </caom2:telescope>
+  <caom2:planes>
+    <caom2:plane caom2:id="0b86be38-8b92-4ed1-8603-e8558b580069">
+      <caom2:productID>TS8004_C_001_20190801</caom2:productID>
+      <caom2:artifacts>
+        <caom2:artifact caom2:id="02ffc49f-0e1b-4eca-b913-001844b0189a">
+          <caom2:uri>uri:foo/bar</caom2:uri>
+          <caom2:productType>science</caom2:productType>
+          <caom2:releaseType>meta</caom2:releaseType>
+          <caom2:contentType>application/measurement-set</caom2:contentType>
+          <caom2:contentLength>14934759161</caom2:contentLength>
+          <caom2:contentChecksum>md5:7c2735ba8142e278932368345579e6fe</caom2:contentChecksum>
+          <caom2:parts/>
+        </caom2:artifact>
+      </caom2:artifacts>
+    </caom2:plane>
+  </caom2:planes>
+</caom2:Observation>

--- a/output_xml/TS8004_C_001_20190801.xml
+++ b/output_xml/TS8004_C_001_20190801.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="94ed5d99-af06-4cfe-be9b-485a68d79d20">
+<caom2:Observation xmlns:caom2="http://www.opencadc.org/caom2/xml/v2.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="caom2:SimpleObservation" caom2:id="2f640f88-1973-433d-bb7c-06e2e7f53b23">
   <caom2:collection>collection</caom2:collection>
   <caom2:observationID>TS8004_C_001_20190801</caom2:observationID>
   <caom2:algorithm>
@@ -9,29 +9,35 @@
   <caom2:target>
     <caom2:name>TBD</caom2:name>
     <caom2:keywords>
-      <caom2:keyword>1252+5634</caom2:keyword>
-      <caom2:keyword>1302+5748</caom2:keyword>
-      <caom2:keyword>0319+4130</caom2:keyword>
       <caom2:keyword>1331+3030</caom2:keyword>
       <caom2:keyword>1407+2827</caom2:keyword>
+      <caom2:keyword>1302+5748</caom2:keyword>
+      <caom2:keyword>0319+4130</caom2:keyword>
+      <caom2:keyword>1252+5634</caom2:keyword>
     </caom2:keywords>
   </caom2:target>
   <caom2:telescope>
     <caom2:name>e-MERLIN</caom2:name>
     <caom2:keywords>
-      <caom2:keyword>Mk2</caom2:keyword>
-      <caom2:keyword>De</caom2:keyword>
       <caom2:keyword>Kn</caom2:keyword>
-      <caom2:keyword>Cm</caom2:keyword>
       <caom2:keyword>Pi</caom2:keyword>
+      <caom2:keyword>Cm</caom2:keyword>
+      <caom2:keyword>De</caom2:keyword>
       <caom2:keyword>Da</caom2:keyword>
+      <caom2:keyword>Mk2</caom2:keyword>
     </caom2:keywords>
   </caom2:telescope>
   <caom2:planes>
-    <caom2:plane caom2:id="0b86be38-8b92-4ed1-8603-e8558b580069">
+    <caom2:plane caom2:id="62e0e669-0e29-441c-9ad9-88f63db89024">
       <caom2:productID>TS8004_C_001_20190801</caom2:productID>
+      <caom2:energy>
+        <caom2:bounds>
+          <caom2:lower>0.056272634068512434</caom2:lower>
+          <caom2:upper>0.06224280244991176</caom2:upper>
+        </caom2:bounds>
+      </caom2:energy>
       <caom2:artifacts>
-        <caom2:artifact caom2:id="02ffc49f-0e1b-4eca-b913-001844b0189a">
+        <caom2:artifact caom2:id="9690c597-f534-4679-be41-003943157e38">
           <caom2:uri>uri:foo/bar</caom2:uri>
           <caom2:productType>science</caom2:productType>
           <caom2:releaseType>meta</caom2:releaseType>


### PR DESCRIPTION
Updates made to casa_reader.py to implement casatools functions in python methods to collect observation-based metadata elements from e-MERLIN measurment sets and return them in a python dictionary.

Updates made to main_app.py to correctly format and assign the observation metadata to CAOM2.4 objects and elements.  

The test.py script was run against these scripts using our test dataset TS8004_C_001_20190801 and output_xml/TS8004_C_001_20190801.xml was checked for correct ouptut.  
