### PR TITLE
Mult targets

### DIFF
--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -106,7 +106,11 @@ def emerlin_band(freq):
     return band
 
 def freq2wl(freq):
-    # Convert frequency (Hz) to wavelength (m)
+    """
+    Convert frequency (Hz) to wavelength (m)
+    :param freq: Frequency to convert
+    :returns: wavelength
+    """
     sol = 299792458
     wl = sol/freq
     return wl
@@ -115,7 +119,7 @@ def get_polar(ms_file):
     """
     Get polarisation state
     :param ms_file: Name of measurement set
-    :returns: polarization type and number of dimensions.
+    :returns: polarisation type and number of dimensions.
     """
     tb.open(ms_file+'/FEED')
     polarization = tb.getcol('POLARIZATION_TYPE')
@@ -153,6 +157,11 @@ def target_position(ms_file, target):
     return [source_coords_ra, source_coords_dec]
   
 def polar2cart(r, theta, phi):
+    """
+    Convert frequency (Hz) to wavelength (m)
+    :param freq: Frequency to convert
+    :returns: wavelength
+    """
     x = r * math.sin(theta) * math.cos(phi)
     y = r * math.sin(theta) * math.sin(phi)
     z = r * math.cos(theta)
@@ -171,6 +180,11 @@ def get_release_date(ms_file):
     return rel_date
 
 def mjdtodate(mjd):
+    """
+    Converts date from MJD to the conventional format
+    :param mjd: date in mjd
+    :returns: date in pedestrian format
+    """
     origin = datetime.datetime(1858,11,17)
     date = origin + datetime.timedelta(mjd)
     return date

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -19,12 +19,15 @@ def msmd_collect(ms_file, targ_name):
     metadata
 
     """
+    
     msmd.open(ms_file)
     nspw = msmd.nspw()
 
     antenna_ids = msmd.antennaids()
     field_ids = range(msmd.nfields())
-
+    targets = targ_name.split(",")
+    if len(targets) > 1:
+        print("Warning: Multiple Science Targets, Position included for first target only.")
     first_scan = msmd.scannumbers()[0]    
 
     msmd_elements = {
@@ -41,7 +44,7 @@ def msmd_collect(ms_file, targ_name):
         'chan_res': msmd.chanwidths(0)[0],
         'nchan'   : nspw * len(msmd.chanwidths(0)),
         'prop_id' : msmd.projects()[0],
-        'num_scans': len(msmd.scansforfield(targ_name)),
+       # 'num_scans': [len(msmd.scansforfield(x)) for x in targ_names],
         'int_time' : msmd.exposuretime(first_scan)['value']
     }
 
@@ -140,11 +143,12 @@ def target_position(ms_file, target):
     :param target: target object name
     :returns: [ra, dec] in degrees
     """
+    targets = target.split(",")
     tb.open(ms_file+'/FIELD')
     source_name = tb.getcol('NAME')
     source_ref = tb.getcol('REFERENCE_DIR')
-    source_coords_ra = np.rad2deg(source_ref[0][0][source_name.tolist().index(target)]) % 360
-    source_coords_dec = np.rad2deg(source_ref[1][0][source_name.tolist().index(target)]) % 360
+    source_coords_ra = np.rad2deg(source_ref[0][0][source_name.tolist().index(targets[0])]) % 360
+    source_coords_dec = np.rad2deg(source_ref[1][0][source_name.tolist().index(targets[0])]) % 360
     tb.close()
     return [source_coords_ra, source_coords_dec]
   

--- a/emerlin2caom2/casa_reader.py
+++ b/emerlin2caom2/casa_reader.py
@@ -44,7 +44,7 @@ def msmd_collect(ms_file, targ_name):
         'chan_res': msmd.chanwidths(0)[0],
         'nchan'   : nspw * len(msmd.chanwidths(0)),
         'prop_id' : msmd.projects()[0],
-       # 'num_scans': [len(msmd.scansforfield(x)) for x in targ_names],
+        #'num_scans': len(msmd.scansforfield(targets[0])),
         'int_time' : msmd.exposuretime(first_scan)['value']
     }
 
@@ -58,7 +58,7 @@ def msmd_collect(ms_file, targ_name):
     elements_convert = {
         'wl_upper': freq2wl(msmd_elements['wl_upper']),
         'wl_lower': freq2wl(msmd_elements['wl_lower']),
-        'chan_res': msmd_elements['chan_res']/1e9, 
+        'chan_res': freq2wl(msmd_elements['chan_res']), 
         'bp_name': emerlin_band(msmd_elements['wl_upper']),
     }
 

--- a/emerlin2caom2/fits_reader.py
+++ b/emerlin2caom2/fits_reader.py
@@ -2,6 +2,11 @@ from astropy.io import fits
 
 
 def header_extraction(fits_file):
+    """
+    Function to extract CAOM relevant metadata from fits files.
+    :param fits_file: name and location of fits file
+    :returns: dictionary of metadata
+    """
     hdu = fits.open(fits_file)
     newhead = hdu[0].header
 

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -175,7 +175,7 @@ class EmerlinMetadata:
         
         time_sample = shape.SubInterval(ms_other["obs_start_time"], ms_other["obs_stop_time"])
         plane.time.bounds = Interval(ms_other["obs_start_time"], ms_other["obs_stop_time"], samples=[time_sample])
-        plane.time.exposure = msmd_dict["int_time"]
+        #plane.time.exposure = msmd_dict["int_time"]
         #plane.time.dimension = msmd_dict["num_scans"]
 
         plane.polarization = Polarization()

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -176,7 +176,7 @@ class EmerlinMetadata:
         time_sample = shape.SubInterval(ms_other["obs_start_time"], ms_other["obs_stop_time"])
         plane.time.bounds = Interval(ms_other["obs_start_time"], ms_other["obs_stop_time"], samples=[time_sample])
         plane.time.exposure = msmd_dict["int_time"]
-        plane.time.dimension = msmd_dict["num_scans"]
+        #plane.time.dimension = msmd_dict["num_scans"]
 
         plane.polarization = Polarization()
         #pol_states, dim = casa.get_polar(ms_dir)

--- a/emerlin2caom2/settings_file.py
+++ b/emerlin2caom2/settings_file.py
@@ -4,4 +4,4 @@ xmldir = '' # directory where xml file will be generated, e.g. './data/'
 upload = True
 replace_old_data = True
 rootca = '' # location of rootCA.pem file
-ska_token = '' # ska beraer token
+ska_token = '' # ska bearer token


### PR DESCRIPTION
Using CY14205 as a test case, amended casa_reader.py to manage multiple primary science targets more gracefully.  
Observation.target.name remains a comma-delimited list in the database upload, however, code now selects the first in the list to pass to casatools before casatools collects target position values.  
Thus, information is lost regarding target position values for second or subsequent sci targets, but there is a warning message (currently to std_out) which, when diverted to logs, will remind us that this observation has been ingested for multiple targets.  
Not sustainable, but a workaround to avoid fatal errors for now.

Also folded in changes from Branch CY10206, to implement similar handling for spectral line measurement sets, so that some information is ingested in the form of a Plane for each spectral line _sp.ms product.  

Tested with caomdev package/caom2.4 ingest.