### PR TITLE
Fixes small bug in ingest_manager 

### DIFF
--- a/emerlin2caom2/api_requests.py
+++ b/emerlin2caom2/api_requests.py
@@ -6,11 +6,9 @@ def request_post(self, xml_output_name):
     """
     Post (new) target XML data onto the database.
     Note this is flipped and was formerly 'put' in torkeep.
-    In recommended curl command, --data item has an @ before it. --data "@TS8004_C_001_20190801_De.xml"
     :param xml_output_name: ObservationID of xml file to post
     """
     post_file = xml_output_name
-    xml_output_name = "@" + xml_output_name
     url_post = self.base_url
     headers_post = {'Content-type': 'application/xml', 'accept': 'application/xml'}
     res = requests.post(url_post, data=open(post_file, 'rb'), verify=self.rootca, headers=headers_post)

--- a/emerlin2caom2/api_requests.py
+++ b/emerlin2caom2/api_requests.py
@@ -31,20 +31,6 @@ def request_delete(self, to_del):
         print(res.status_code + ": Delete may have failed for " + to_del) # can remove once code no longer needs debugging
     return res.status_code
 
-def request_delete(self, to_del):
-    """
-    Deletes target XML data on the database.
-    :param to_del: ObservationID of target data to delete
-    """
-    url_del = self.base_url + '/' + to_del
-    # print(url_del) # can remove once code no longer needs debugging
-    res = requests.delete(url_del, verify=self.rootca)
-    if res.status_code == 204:
-        print(to_del + " has been deleted.")
-    else:
-        print(res.status_code + ": Delete may have failed for " + to_del) # can remove once code no longer needs debugging
-    return res.status_code
-
 def request_get(self, file_to_get=''):
     """
     Get target data from database based on observations/uri. NOT YET FUNCTIONAL WITH API.

--- a/emerlin2caom2/api_requests.py
+++ b/emerlin2caom2/api_requests.py
@@ -26,7 +26,7 @@ def request_delete(self, to_del):
     if res.status_code == 204:
         print(to_del + " has been deleted.")
     else:
-        print("Delete may have failed for " + to_del) # can remove once code no longer needs debugging
+        print(str(res.status_code) + ": Delete may have failed for " + to_del) # can remove once code no longer needs debugging
     return res.status_code
 
 def request_get(self, file_to_get=''):

--- a/emerlin2caom2/api_requests.py
+++ b/emerlin2caom2/api_requests.py
@@ -28,7 +28,7 @@ def request_delete(self, to_del):
     if res.status_code == 204:
         print(to_del + " has been deleted.")
     else:
-        print(res.status_code + ": Delete may have failed for " + to_del) # can remove once code no longer needs debugging
+        print("Delete may have failed for " + to_del) # can remove once code no longer needs debugging
     return res.status_code
 
 def request_get(self, file_to_get=''):

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -465,8 +465,7 @@ class EmerlinMetadata:
                     if del_stat == 204:
                         print(obs_uri + " deleted.")
                     else:
-                        print(obs_uri + " attempted delete with status code:")
-                        print(del_stat)
+                        print(obs_uri + " attempted delete with status code: " + str(del_stat))
                     create_stat = api.request_post(self, xml_output_name)
                     if create_stat == 201:
                         print(obs_uri + " ingested.")
@@ -479,7 +478,6 @@ class EmerlinMetadata:
                 if create_stat == 201:
                     print(obs_uri + " ingested.")
                 else:
-                    print(obs_uri + " attempted insert with status code:")
-                    print(create_stat)
+                    print(obs_uri + " attempted insert with status code: " + str(create_stat))
 
 

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -465,7 +465,8 @@ class EmerlinMetadata:
                     if del_stat == 204:
                         print(obs_uri + " deleted.")
                     else:
-                        print(obs_uri + " attempted delete with status code " + del_stat)
+                        print(obs_uri + " attempted delete with status code:")
+                        print(del_stat)
                     create_stat = api.request_post(self, xml_output_name)
                     if create_stat == 201:
                         print(obs_uri + " ingested.")
@@ -478,6 +479,7 @@ class EmerlinMetadata:
                 if create_stat == 201:
                     print(obs_uri + " ingested.")
                 else:
-                    print(obs_uri + "attempted update with status code: " + create_stat)
+                    print(obs_uri + " attempted insert with status code:")
+                    print(create_stat)
 
 


### PR DESCRIPTION
Ingest manager was failing one of the if statement cases due to print var type mismatch which was somehow missed before, so that should be fixed now.  Would only come across it in unexpected cases of database duplicates or errors in ingest/delete.