### PR TITLE
Altering upload

### DIFF
--- a/emerlin2caom2/api_requests.py
+++ b/emerlin2caom2/api_requests.py
@@ -11,7 +11,7 @@ def request_post(self, xml_output_name):
     post_file = xml_output_name
     url_post = self.base_url
     headers_post = {'Content-type': 'application/xml', 'accept': 'application/xml'}
-    res = requests.post(url_post, data=open(post_file, 'rb'), verify=self.rootca, headers=headers_post)
+    res = requests.post(url_post, data=open(post_file, 'rb'), headers=headers_post)
     # print(res.status_code) # can remove once code no longer needs debugging
     return res.status_code
 
@@ -22,7 +22,7 @@ def request_delete(self, to_del):
     """
     url_del = self.base_url + '/' + to_del
     # print(url_del) # can remove once code no longer needs debugging
-    res = requests.delete(url_del, verify=self.rootca)
+    res = requests.delete(url_del)
     if res.status_code == 204:
         print(to_del + " has been deleted.")
     else:
@@ -38,7 +38,7 @@ def request_get(self, file_to_get=''):
     #url_get = self.base_url + '/' + file_to_get
     url_get = self.base_url
     print(url_get) # can remove once code no longer needs debugging
-    res = requests.get(url_get, params=payload, verify=self.rootca)
+    res = requests.get(url_get, params=payload)
     print(res) # can remove once code no longer needs debugging
 
 
@@ -76,7 +76,7 @@ def request_tap(self, obs_id):
 
     if url_tap:
         print('location: ' + url_tap)
-        res = requests.get(url_tap, verify=self.rootca)
+        res = requests.get(url_tap)
         print(res)
         print(res.text)
         print(res.text[1][0])

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -102,10 +102,6 @@ class EmerlinMetadata:
         xml_out_dir += '/'
 
     base_url = set_f.base_url
-    #base_url = 'http://localhost:8080/observations/'
-    #base_url = 'https://src-data-repo.co.uk/torkeep/observations/EMERLIN'
-    # rootca = set_f.rootca
-    #ska_token = set_f.ska_token
     obs_id = basename(storage_name)
     ms_dir_main = storage_name + '/{}_avg.ms'.format(obs_id)  # maybe flimsy? depends on the rigidity of the em pipeline
     ms_dir_spectral = storage_name + '/{}_sp.ms'.format(obs_id)

--- a/emerlin2caom2/main_app.py
+++ b/emerlin2caom2/main_app.py
@@ -104,7 +104,7 @@ class EmerlinMetadata:
     base_url = set_f.base_url
     #base_url = 'http://localhost:8080/observations/'
     #base_url = 'https://src-data-repo.co.uk/torkeep/observations/EMERLIN'
-    rootca = set_f.rootca
+    # rootca = set_f.rootca
     #ska_token = set_f.ska_token
     obs_id = basename(storage_name)
     ms_dir_main = storage_name + '/{}_avg.ms'.format(obs_id)  # maybe flimsy? depends on the rigidity of the em pipeline
@@ -460,7 +460,7 @@ class EmerlinMetadata:
         if set_f.upload:
             machine_id = api.find_existing(self, obs_uri)
             if machine_id:
-                if (set_f.replace_old_data) and isinstance(machine_id, str):
+                if set_f.replace_old_data and isinstance(machine_id, str):
                     del_stat = api.request_delete(self, machine_id)
                     if del_stat == 204:
                         print(obs_uri + " deleted.")

--- a/emerlin2caom2/settings_file.py
+++ b/emerlin2caom2/settings_file.py
@@ -4,4 +4,3 @@ xmldir = '' # directory where xml file will be generated, e.g. './data/'
 upload = True
 replace_old_data = True
 base_url = '' # location of database e.g. 'https://src-data-repo.co.uk/torkeep/observations/EMERLIN'
-rootca = '' # location of rootCA.pem file


### PR DESCRIPTION
Removing the rootCA certificate from the requests to the metadata database. 
Now the code should upload to kilburn from outside the Manchester network without issue.
Tap is also working properly. 